### PR TITLE
Update base image to alpine:3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.15
 RUN apk add --no-cache curl
 ADD Watch /
 ENTRYPOINT ["/Watch"]


### PR DESCRIPTION
Needs a rebuild anyway to pickup the latest patch release on the current 3.13 which carries critical + high vulnerabilities. 
May as well bump it now to 3.15 which has 0 vulnerabilities.